### PR TITLE
Quick Install ChemShell Code Option

### DIFF
--- a/docs/source/user_guide/resource_management.rst
+++ b/docs/source/user_guide/resource_management.rst
@@ -110,11 +110,12 @@ in the workflow wizard.
 .. note::
 
     If no suitable recipe exists for your computer/code combination in any available
-    database, use the :ref:`Manual Setup <resource_management>` instead by ticking the
+    database, use the :ref:`Manual Setup <_resource_manual_setup>` instead by ticking the
     *Tick checkbox to setup resource step by step* option described below or get in touch
     with your chosen registry maintainers e.g. 
     `Ada Lovelace Centre <https://github.com/stfc/alc-ux>` for STFC managed resources.
 
+.. _resource_manual_setup:
 
 Manual Setup
 ------------

--- a/docs/source/user_guide/resource_management.rst
+++ b/docs/source/user_guide/resource_management.rst
@@ -14,8 +14,106 @@ bottom of the page including a search bar to search for a specific codes and the
 hide certain codes from the AiiDAlab interface. The rest of this page is dedicated to 
 configuring new *computer* and *code* instances.
 
+Quick Install ChemShell Container
+---------------------------------
+
+For users running AiiDAlab on their local machine, the top of the resource setup
+page provides a one-click **Install ChemShell Container & Create Code** button. This
+downloads the pre-built ChemShell container image and creates a ready-to-use
+``chemsh@localhost`` *code* instance, removing the need to manually configure a
+*computer* and *code* for local ChemShell runs. It is the quickest way to get up and
+running when using one of the base AiiDAlab images that does not already bundle a full
+ChemShell installation (see :ref:`getting_started`).
+
+.. note::
+
+    This feature requires either the `Apptainer <https://apptainer.org/>`_ **or**
+    `Docker <https://www.docker.com/>`_ container engine to be available on the local
+    machine. Apptainer is preferred and Docker is used automatically as a fallback when
+    Apptainer is not available.
+
+Clicking the button runs the following steps automatically, reporting progress in the
+status area beneath it:
+
+1. **Detect a container engine.** Apptainer is checked first; if it is not present the
+   Docker engine is used instead. Docker is only considered available if its daemon is
+   actually reachable, so a stopped Docker service is reported as unavailable rather than
+   failing later during the build.
+2. **Acquire the container image.** If the ChemShell image is already present locally it
+   is reused, otherwise it is pulled from the GitHub container registry
+   (``ghcr.io/stfc/aiidalab-chemshell/chemsh:latest``). With Apptainer this produces a
+   local ``.sif`` file; with Docker the image is stored in the local daemon's image
+   store. Building the image can take several minutes on the first run.
+3. **Create the AiiDA code.** A containerised ``chemsh@localhost`` *code* is created
+   pointing at the ChemShell executable inside the image. If a ChemShell code already
+   exists it is reused rather than recreated.
+
+Once the process completes successfully the code becomes available for selection in the
+workflow wizard just like any manually configured code.
+
+.. note::
+
+    Containerised codes require the ``use double quotes to escape...`` option to be
+    enabled on the host *computer* so that the ``$PWD`` reference in the container engine
+    command is expanded correctly. The installer enables this setting automatically on
+    the ``localhost`` computer if it is not already set, and reports in the status
+    message when it has done so. See :ref:`resource_management` for the equivalent manual
+    option.
+
 Quick Setup
 -----------
+
+The *Create New Code* section provides a **Quick setup** utility for configuring
+*code* instances on remote machines without having to enter every field by hand.
+Rather than describing a computer and code from scratch, the quick setup reads a set of
+pre-defined *recipes* from a database file and lets you pick a ready-made
+combination.
+
+Resource Database Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recipes are loaded from the JSON database referenced in the **Source** field at the
+top of the section. By default this points at an STFC maintained
+database of resources, providing quick access to codes on STFC managed computers such as
+SCARF:
+
+.. code:: text
+
+    https://raw.githubusercontent.com/stfc/alc-ux/refs/heads/main/resources/remotes.json
+
+To use a different collection of recipes simply edit the URL in the **Source** field to
+point at your chosen JSON database. An example would the the default AiiDA resource 
+registry database which can be found at:
+
+.. code:: text 
+
+    https://aiidateam.github.io/aiida-resource-registry/database.json
+
+
+Configuring a Code
+~~~~~~~~~~~~~~~~~~
+
+Once a source is selected, configure a new code using the following steps:
+
+1. **Select the domain** of your remote machine.
+2. **Select the computer recipe** for the target machine.
+3. **Select the code recipe** for the software you wish to run.
+4. **Complete the remaining fields**. The fields presented here depend on the combination
+   chosen in steps 1-3 and typically cover account-specific details such as your remote
+   username.
+5. Click **Quick setup**.
+
+This will automatically run the computer and code setup steps on the background for 
+the given pre-configured recipe. The new code will then be available for selection
+in the workflow wizard.
+
+.. note::
+
+    If no suitable recipe exists for your computer/code combination in any available
+    database, use the :ref:`Manual Setup <resource_management>` instead by ticking the
+    *Tick checkbox to setup resource step by step* option described below or get in touch
+    with your chosen registry maintainers e.g. 
+    `Ada Lovelace Centre <https://github.com/stfc/alc-ux>` for STFC managed resources.
 
 
 Manual Setup

--- a/notebooks/resources.ipynb
+++ b/notebooks/resources.ipynb
@@ -80,11 +80,7 @@
    "cell_type": "markdown",
    "id": "d720d857",
    "metadata": {},
-   "source": [
-    "# Quick Install ChemShell Container\n",
-    "\n",
-    "Install the ChemShell container and create a ready-to-use AiiDA code. Note: this requires the apptainer container engine to be available on the local machine. "
-   ]
+   "source": "# Quick Install ChemShell Container\n\nInstall the ChemShell container and create a ready-to-use AiiDA code. Note: this requires the Apptainer **or** Docker container engine to be available on the local machine. Apptainer is preferred; Docker is used automatically as a fallback when Apptainer is not available."
   },
   {
    "cell_type": "code",

--- a/notebooks/resources.ipynb
+++ b/notebooks/resources.ipynb
@@ -22,14 +22,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0cb00139",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from aiida import load_profile\n",
+    "\n",
     "load_profile();"
    ]
   },
@@ -81,6 +78,38 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d720d857",
+   "metadata": {},
+   "source": [
+    "# Quick Install ChemShell Container\n",
+    "\n",
+    "Install the ChemShell container and create a ready-to-use AiiDA code. Note: this requires the apptainer container engine to be available on the local machine. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5434a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import VBox\n",
+    "\n",
+    "from aiidalab_chemshell.common.utils import LoadingWidget\n",
+    "from aiidalab_chemshell.resources import ChemShellContainerSetupWidget\n",
+    "\n",
+    "container_setup_widget_container = VBox(\n",
+    "    children=[\n",
+    "        LoadingWidget(\"Loading container setup widget\"),\n",
+    "    ],\n",
+    ")\n",
+    "display(container_setup_widget_container)\n",
+    "\n",
+    "container_setup_widget_container.children = [ChemShellContainerSetupWidget()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "345f06cb",
    "metadata": {},
    "source": [
@@ -109,15 +138,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b4537d8b",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from aiidalab_chemshell.common.utils import LoadingWidget\n",
     "from ipywidgets import VBox\n",
+    "\n",
+    "from aiidalab_chemshell.common.utils import LoadingWidget\n",
     "\n",
     "new_codes_widget_container = VBox(\n",
     "    children=[\n",
@@ -141,11 +167,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "df625ced",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from aiidalab_chemshell.common.utils import LoadingWidget\n",
@@ -162,38 +184,29 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c2f8eb81",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from aiidalab_chemshell.resources import CodeSetupWidget\n",
     "\n",
-    "new_codes_widget_container.children = [\n",
-    "    CodeSetupWidget()\n",
-    "]"
+    "new_codes_widget_container.children = [CodeSetupWidget()]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "c7211ea0",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from home.code_setup import create_paginated_table, fetch_code_data\n",
-    "from ipywidgets import Output, Button, Layout\n",
+    "from ipywidgets import Button, Layout, Output\n",
     "\n",
     "output = Output()\n",
     "\n",
     "\n",
     "def render():\n",
+    "    \"\"\"Render the UI.\"\"\"\n",
     "    data = fetch_code_data()\n",
     "    paginated_table = create_paginated_table(data)\n",
     "    output.clear_output()\n",
@@ -222,22 +235,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5a672ad7",
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def on_code_setup_message_change(change):\n",
+    "    \"\"\"Re-render the UI with updated status message.\"\"\"\n",
     "    if \"created\" in change[\"new\"]:\n",
     "        render()\n",
     "\n",
     "\n",
-    "#widget.aiida_code_setup.observe(\n",
+    "# widget.aiida_code_setup.observe(\n",
     "#    on_code_setup_message_change,\n",
     "#    \"message\",\n",
-    "#)"
+    "# )"
    ]
   }
  ],

--- a/src/aiidalab_chemshell/containers.py
+++ b/src/aiidalab_chemshell/containers.py
@@ -391,8 +391,42 @@ def get_localhost_computer():
     computer.store()
     computer.set_minimum_job_poll_interval(0)
     computer.set_default_mpiprocs_per_machine(1)
+    # Required for containerized codes (see ``ensure_use_double_quotes``).
+    computer.set_use_double_quotes(True)
     computer.configure()
     return computer
+
+
+def ensure_use_double_quotes(computer) -> bool:
+    """
+    Ensure ``computer`` escapes command-line arguments with double quotes.
+
+    Containerized codes require this: the ``engine_command`` relies on shell
+    variable expansion (``$PWD`` in the bind-mount arguments), which only happens
+    inside double quotes. With the AiiDA default of single-quote escaping the
+    ``$PWD`` token is passed literally and the bind mount is broken.
+
+    The setting is computer-wide but narrow in reach: it governs the escaping of
+    the engine command, MPI arguments and the ``stdin``/``stdout``/``stderr``
+    file names. Each code's own executable and arguments are escaped by the
+    separate per-code ``use_double_quotes`` attribute, so enabling this does not
+    change how other codes' arguments are quoted.
+
+    Parameters
+    ----------
+    computer : aiida.orm.Computer
+        The computer to check and, if necessary, update.
+
+    Returns
+    -------
+    bool
+        True if the setting was changed (was disabled, now enabled), False if it
+        was already enabled.
+    """
+    if computer.get_use_double_quotes():
+        return False
+    computer.set_use_double_quotes(True)
+    return True
 
 
 def _code_params(engine: str) -> tuple[str, str, str]:
@@ -442,6 +476,9 @@ def create_chemshell_code(engine: str = APPTAINER):
 
     engine_command, image_name, description = _code_params(engine)
     computer = get_localhost_computer()
+    # Containerized codes need double-quote escaping so the engine command's
+    # ``$PWD`` expands; enforce it here so every caller gets a working code.
+    ensure_use_double_quotes(computer)
     code = ContainerizedCode(
         computer=computer,
         engine_command=engine_command,

--- a/src/aiidalab_chemshell/containers.py
+++ b/src/aiidalab_chemshell/containers.py
@@ -1,0 +1,239 @@
+"""Logic for installing the ChemShell container and creating an AiiDA code.
+
+This module contains the pure (non-UI) logic used to provision a ChemShell
+runtime for AiiDA. The intended flow is:
+
+1. Check that Apptainer is installed and can be executed.
+2. Reuse an existing local ``.sif`` image, or build one by pulling the
+   project's image from the GitHub Container Registry.
+3. Create (or reuse) an AiiDA :class:`~aiida.orm.ContainerizedCode` on the
+   ``localhost`` computer pointing at the ``.sif`` file.
+
+Apptainer is supported first; the function signatures are structured so that a
+Docker engine can be added later without changing the public interface.
+"""
+
+import pathlib
+import subprocess
+from collections.abc import Callable
+
+# --- Container / image configuration --------------------------------------
+CONTAINER_IMAGE = "ghcr.io/stfc/aiidalab-chemshell/chemsh"
+CONTAINER_TAG = "latest"
+CONTAINER_IMAGE_URI = f"docker://{CONTAINER_IMAGE}:{CONTAINER_TAG}"
+
+# The ``.sif`` is stored under the user's home directory
+CONTAINER_DIR = pathlib.Path.home() / ".aiidalab-chemshell" / "containers"
+SIF_FILENAME = f"chemshell-{CONTAINER_TAG}.sif"
+
+# --- AiiDA code configuration ---------------------------------------------
+CODE_LABEL = "chemsh"
+COMPUTER_LABEL = "localhost"
+ENGINE_COMMAND = "apptainer exec --bind $PWD:$PWD --cleanenv {image_name}"
+FILEPATH_EXECUTABLE = "/opt/chemsh-py/bin/intel/chemsh"
+DEFAULT_CALC_JOB_PLUGIN = "chemshell"
+PREPEND_TEXT = ""
+APPEND_TEXT = ""
+WITH_MPI = False
+
+# Timeout (seconds) for the quick Apptainer availability check.
+_APPTAINER_CHECK_TIMEOUT = 30
+
+
+def sif_path() -> pathlib.Path:
+    """
+    Return the absolute path to the local ChemShell ``.sif`` image.
+
+    Returns
+    -------
+    pathlib.Path
+        The path where the ``.sif`` image is (or would be) stored.
+    """
+    return CONTAINER_DIR / SIF_FILENAME
+
+
+def sif_exists() -> bool:
+    """
+    Return whether the local ChemShell ``.sif`` image already exists.
+
+    Returns
+    -------
+    bool
+        True if the ``.sif`` file exists, False otherwise.
+    """
+    return sif_path().is_file()
+
+
+def check_apptainer() -> tuple[bool, str]:
+    """
+    Check that Apptainer is installed and can be executed.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple ``(ok, message)`` where ``ok`` is True if Apptainer is
+        available and returned successfully. ``message`` contains the reported
+        version on success or a human-readable error otherwise.
+    """
+    try:
+        result = subprocess.run(
+            ["apptainer", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_APPTAINER_CHECK_TIMEOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            False,
+            "Apptainer was not found on this system. Please install Apptainer "
+            "and ensure it is available on the PATH.",
+        )
+    except subprocess.SubprocessError as exc:
+        return (False, f"Failed to run Apptainer: {exc}")
+
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip()
+        return (
+            False,
+            f"Apptainer is installed but returned an error: {error}",
+        )
+
+    return (True, result.stdout.strip())
+
+
+def build_sif(on_progress: Callable[[str], None] | None = None) -> tuple[bool, str]:
+    """
+    Build the local ChemShell ``.sif`` image by pulling from the registry.
+
+    This pulls :data:`CONTAINER_IMAGE_URI` into :func:`sif_path` using
+    ``apptainer pull``.
+
+    Parameters
+    ----------
+    on_progress : Callable[[str], None], optional
+        Optional callback invoked with human-readable progress messages.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple ``(ok, message)`` where ``ok`` is True on success. ``message``
+        contains a success note or the captured error output on failure.
+    """
+
+    def _report(message: str) -> None:
+        if on_progress is not None:
+            on_progress(message)
+
+    CONTAINER_DIR.mkdir(parents=True, exist_ok=True)
+    target = sif_path()
+
+    _report(f"Pulling {CONTAINER_IMAGE_URI} to {target} ...")
+    try:
+        result = subprocess.run(
+            ["apptainer", "pull", str(target), CONTAINER_IMAGE_URI],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (False, "Apptainer was not found on this system.")
+    except subprocess.SubprocessError as exc:
+        return (False, f"Failed to run Apptainer pull: {exc}")
+
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip()
+        return (False, f"Failed to build the container image: {error}")
+
+    return (True, f"Container image built successfully at {target}.")
+
+
+def chemshell_code_exists() -> bool:
+    """
+    Return whether the ChemShell AiiDA code already exists.
+
+    Returns
+    -------
+    bool
+        True if a code labelled ``chemsh@localhost`` exists, False otherwise.
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm import load_code
+
+    try:
+        load_code(f"{CODE_LABEL}@{COMPUTER_LABEL}")
+    except NotExistent:
+        return False
+    return True
+
+
+def get_localhost_computer():
+    """
+    Return the ``localhost`` AiiDA computer, creating it if necessary.
+
+    In AiiDAlab deployments the ``localhost`` computer is normally pre-created
+    by the base-image startup scripts, so this typically just loads it. If it
+    does not exist, a minimal local computer is created and configured as a
+    safety fallback.
+
+    Returns
+    -------
+    aiida.orm.Computer
+        The configured ``localhost`` computer.
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm import Computer, load_computer
+
+    try:
+        return load_computer(COMPUTER_LABEL)
+    except NotExistent:
+        pass
+
+    computer = Computer(
+        label=COMPUTER_LABEL,
+        hostname=COMPUTER_LABEL,
+        workdir=str(pathlib.Path.home() / "aiida_run"),
+        transport_type="core.local",
+        scheduler_type="core.direct",
+    )
+    computer.store()
+    computer.set_minimum_job_poll_interval(0)
+    computer.set_default_mpiprocs_per_machine(1)
+    computer.configure()
+    return computer
+
+
+def create_chemshell_code():
+    """
+    Create (or reuse) the ChemShell containerized AiiDA code.
+
+    If a code labelled ``chemsh@localhost`` already exists it is loaded and
+    returned unchanged. Otherwise a new
+    :class:`~aiida.orm.ContainerizedCode` is created pointing at the local
+    ``.sif`` image, stored, and returned.
+
+    Returns
+    -------
+    aiida.orm.ContainerizedCode
+        The stored (or pre-existing) ChemShell code.
+    """
+    from aiida.orm import ContainerizedCode, load_code
+
+    if chemshell_code_exists():
+        return load_code(f"{CODE_LABEL}@{COMPUTER_LABEL}")
+
+    computer = get_localhost_computer()
+    code = ContainerizedCode(
+        computer=computer,
+        engine_command=ENGINE_COMMAND,
+        image_name=str(sif_path()),
+        filepath_executable=FILEPATH_EXECUTABLE,
+        label=CODE_LABEL,
+        default_calc_job_plugin=DEFAULT_CALC_JOB_PLUGIN,
+        with_mpi=WITH_MPI,
+        prepend_text=PREPEND_TEXT,
+        append_text=APPEND_TEXT,
+    )
+    code.store()
+    code.is_hidden = False
+    return code

--- a/src/aiidalab_chemshell/containers.py
+++ b/src/aiidalab_chemshell/containers.py
@@ -229,6 +229,7 @@ def create_chemshell_code():
         image_name=str(sif_path()),
         filepath_executable=FILEPATH_EXECUTABLE,
         label=CODE_LABEL,
+        description="ChemShell v25 (Apptainer)",
         default_calc_job_plugin=DEFAULT_CALC_JOB_PLUGIN,
         with_mpi=WITH_MPI,
         prepend_text=PREPEND_TEXT,

--- a/src/aiidalab_chemshell/containers.py
+++ b/src/aiidalab_chemshell/containers.py
@@ -3,24 +3,33 @@
 This module contains the pure (non-UI) logic used to provision a ChemShell
 runtime for AiiDA. The intended flow is:
 
-1. Check that Apptainer is installed and can be executed.
-2. Reuse an existing local ``.sif`` image, or build one by pulling the
-   project's image from the GitHub Container Registry.
+1. Detect an available container engine (Apptainer first, then Docker).
+2. Reuse an existing local image, or acquire one by pulling the project's
+   image from the GitHub Container Registry.
 3. Create (or reuse) an AiiDA :class:`~aiida.orm.ContainerizedCode` on the
-   ``localhost`` computer pointing at the ``.sif`` file.
+   ``localhost`` computer pointing at that image.
 
-Apptainer is supported first; the function signatures are structured so that a
-Docker engine can be added later without changing the public interface.
+Apptainer is preferred; Docker is used automatically as a fallback when
+Apptainer is not available. The two engines differ in how images are stored
+(Apptainer keeps a local ``.sif`` file, Docker keeps the image in its daemon's
+store) and in the ``engine_command`` used by the created code, but the executable
+path, code label and bind convention are identical for both.
 """
 
 import pathlib
 import subprocess
 from collections.abc import Callable
 
+# --- Engine identifiers ----------------------------------------------------
+APPTAINER = "apptainer"
+DOCKER = "docker"
+
 # --- Container / image configuration --------------------------------------
 CONTAINER_IMAGE = "ghcr.io/stfc/aiidalab-chemshell/chemsh"
 CONTAINER_TAG = "latest"
+# Apptainer pulls from a ``docker://`` URI; Docker uses the bare image ref.
 CONTAINER_IMAGE_URI = f"docker://{CONTAINER_IMAGE}:{CONTAINER_TAG}"
+DOCKER_IMAGE = f"{CONTAINER_IMAGE}:{CONTAINER_TAG}"
 
 # The ``.sif`` is stored under the user's home directory
 CONTAINER_DIR = pathlib.Path.home() / ".aiidalab-chemshell" / "containers"
@@ -29,15 +38,20 @@ SIF_FILENAME = f"chemshell-{CONTAINER_TAG}.sif"
 # --- AiiDA code configuration ---------------------------------------------
 CODE_LABEL = "chemsh"
 COMPUTER_LABEL = "localhost"
-ENGINE_COMMAND = "apptainer exec --bind $PWD:$PWD --cleanenv {image_name}"
+APPTAINER_ENGINE_COMMAND = "apptainer exec --bind $PWD:$PWD --cleanenv {image_name}"
+DOCKER_ENGINE_COMMAND = (
+    "docker run -v $PWD:/workspace -w /workspace --rm --ipc=host "
+    "--entrypoint= {image_name}"
+)
 FILEPATH_EXECUTABLE = "/opt/chemsh-py/bin/intel/chemsh"
 DEFAULT_CALC_JOB_PLUGIN = "chemshell"
 PREPEND_TEXT = ""
 APPEND_TEXT = ""
 WITH_MPI = False
 
-# Timeout (seconds) for the quick Apptainer availability check.
+# Timeout (seconds) for the quick engine availability checks.
 _APPTAINER_CHECK_TIMEOUT = 30
+_DOCKER_CHECK_TIMEOUT = 30
 
 
 def sif_path() -> pathlib.Path:
@@ -102,6 +116,76 @@ def check_apptainer() -> tuple[bool, str]:
     return (True, result.stdout.strip())
 
 
+def check_docker() -> tuple[bool, str]:
+    """
+    Check that Docker is installed and its daemon is reachable.
+
+    ``docker version --format '{{.Server.Version}}'`` is used because it
+    contacts the daemon: a present CLI with a stopped daemon exits non-zero and
+    is correctly reported as unavailable.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple ``(ok, message)`` where ``ok`` is True if Docker is available
+        and the daemon responded. ``message`` contains the reported server
+        version on success or a human-readable error otherwise.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True,
+            text=True,
+            timeout=_DOCKER_CHECK_TIMEOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            False,
+            "Docker was not found on this system. Please install Docker "
+            "and ensure it is available on the PATH.",
+        )
+    except subprocess.SubprocessError as exc:
+        return (False, f"Failed to run Docker: {exc}")
+
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip()
+        return (
+            False,
+            "Docker is installed but the daemon is not reachable: "
+            f"{error or 'is the Docker daemon running?'}",
+        )
+
+    return (True, result.stdout.strip())
+
+
+def detect_engine() -> tuple[str | None, str]:
+    """
+    Detect an available container engine, preferring Apptainer over Docker.
+
+    Returns
+    -------
+    tuple[str | None, str]
+        A tuple ``(engine, message)``. ``engine`` is :data:`APPTAINER` or
+        :data:`DOCKER` when one is available (Apptainer takes priority), or
+        ``None`` when neither is. ``message`` reports the chosen engine's
+        version on success, or the combined reason both were rejected.
+    """
+    apptainer_ok, apptainer_msg = check_apptainer()
+    if apptainer_ok:
+        return (APPTAINER, apptainer_msg)
+
+    docker_ok, docker_msg = check_docker()
+    if docker_ok:
+        return (DOCKER, docker_msg)
+
+    return (
+        None,
+        "No supported container engine is available. "
+        f"Apptainer: {apptainer_msg} Docker: {docker_msg}",
+    )
+
+
 def build_sif(on_progress: Callable[[str], None] | None = None) -> tuple[bool, str]:
     """
     Build the local ChemShell ``.sif`` image by pulling from the registry.
@@ -146,6 +230,114 @@ def build_sif(on_progress: Callable[[str], None] | None = None) -> tuple[bool, s
         return (False, f"Failed to build the container image: {error}")
 
     return (True, f"Container image built successfully at {target}.")
+
+
+def docker_image_exists() -> bool:
+    """
+    Return whether the ChemShell Docker image is present in the local store.
+
+    Returns
+    -------
+    bool
+        True if ``docker image inspect`` reports the image, False otherwise
+        (including when Docker is unavailable).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", DOCKER_IMAGE],
+            capture_output=True,
+            text=True,
+            timeout=_DOCKER_CHECK_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def pull_docker_image(
+    on_progress: Callable[[str], None] | None = None,
+) -> tuple[bool, str]:
+    """
+    Pull the ChemShell Docker image into the local daemon's image store.
+
+    Parameters
+    ----------
+    on_progress : Callable[[str], None], optional
+        Optional callback invoked with human-readable progress messages.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple ``(ok, message)`` where ``ok`` is True on success. ``message``
+        contains a success note or the captured error output on failure.
+    """
+
+    def _report(message: str) -> None:
+        if on_progress is not None:
+            on_progress(message)
+
+    _report(f"Pulling {DOCKER_IMAGE} ...")
+    try:
+        result = subprocess.run(
+            ["docker", "pull", DOCKER_IMAGE],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (False, "Docker was not found on this system.")
+    except subprocess.SubprocessError as exc:
+        return (False, f"Failed to run Docker pull: {exc}")
+
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip()
+        return (False, f"Failed to pull the container image: {error}")
+
+    return (True, f"Container image {DOCKER_IMAGE} pulled successfully.")
+
+
+def image_exists(engine: str) -> bool:
+    """
+    Return whether the ChemShell image for ``engine`` is already available.
+
+    Parameters
+    ----------
+    engine : str
+        Either :data:`APPTAINER` or :data:`DOCKER`.
+
+    Returns
+    -------
+    bool
+        True if the engine's local image is present, False otherwise.
+    """
+    if engine == DOCKER:
+        return docker_image_exists()
+    return sif_exists()
+
+
+def build_image(
+    engine: str, on_progress: Callable[[str], None] | None = None
+) -> tuple[bool, str]:
+    """
+    Acquire the ChemShell image for ``engine`` (Apptainer pull or Docker pull).
+
+    Parameters
+    ----------
+    engine : str
+        Either :data:`APPTAINER` or :data:`DOCKER`.
+    on_progress : Callable[[str], None], optional
+        Optional callback invoked with human-readable progress messages.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple ``(ok, message)`` as returned by :func:`build_sif` or
+        :func:`pull_docker_image`.
+    """
+    if engine == DOCKER:
+        return pull_docker_image(on_progress=on_progress)
+    return build_sif(on_progress=on_progress)
 
 
 def chemshell_code_exists() -> bool:
@@ -203,14 +395,40 @@ def get_localhost_computer():
     return computer
 
 
-def create_chemshell_code():
+def _code_params(engine: str) -> tuple[str, str, str]:
+    """
+    Return the ``(engine_command, image_name, description)`` for ``engine``.
+
+    Parameters
+    ----------
+    engine : str
+        Either :data:`APPTAINER` or :data:`DOCKER`.
+
+    Returns
+    -------
+    tuple[str, str, str]
+        The ``engine_command``, ``image_name`` and code ``description`` for the
+        requested engine.
+    """
+    if engine == DOCKER:
+        return (DOCKER_ENGINE_COMMAND, DOCKER_IMAGE, "ChemShell v25 (Docker)")
+    return (APPTAINER_ENGINE_COMMAND, str(sif_path()), "ChemShell v25 (Apptainer)")
+
+
+def create_chemshell_code(engine: str = APPTAINER):
     """
     Create (or reuse) the ChemShell containerized AiiDA code.
 
     If a code labelled ``chemsh@localhost`` already exists it is loaded and
     returned unchanged. Otherwise a new
-    :class:`~aiida.orm.ContainerizedCode` is created pointing at the local
-    ``.sif`` image, stored, and returned.
+    :class:`~aiida.orm.ContainerizedCode` is created for the requested engine
+    (pointing at the local ``.sif`` image for Apptainer, or the Docker image
+    ref for Docker), stored, and returned.
+
+    Parameters
+    ----------
+    engine : str, optional
+        Either :data:`APPTAINER` (default) or :data:`DOCKER`.
 
     Returns
     -------
@@ -222,14 +440,15 @@ def create_chemshell_code():
     if chemshell_code_exists():
         return load_code(f"{CODE_LABEL}@{COMPUTER_LABEL}")
 
+    engine_command, image_name, description = _code_params(engine)
     computer = get_localhost_computer()
     code = ContainerizedCode(
         computer=computer,
-        engine_command=ENGINE_COMMAND,
-        image_name=str(sif_path()),
+        engine_command=engine_command,
+        image_name=image_name,
         filepath_executable=FILEPATH_EXECUTABLE,
         label=CODE_LABEL,
-        description="ChemShell v25 (Apptainer)",
+        description=description,
         default_calc_job_plugin=DEFAULT_CALC_JOB_PLUGIN,
         with_mpi=WITH_MPI,
         prepend_text=PREPEND_TEXT,

--- a/src/aiidalab_chemshell/resources.py
+++ b/src/aiidalab_chemshell/resources.py
@@ -118,8 +118,13 @@ class ChemShellContainerSetupWidget(ipw.VBox):
     def _create_code(self, engine: str):
         """Create/reuse the ChemShell code (must run on the main thread)."""
         existed = containers.chemshell_code_exists()
+        # Containerized codes require double-quote escaping on the computer for
+        # the engine command's ``$PWD`` to expand. Enable it if needed (also
+        # covers the code-reuse path) and report whether we changed it.
+        computer = containers.get_localhost_computer()
+        dq_changed = containers.ensure_use_double_quotes(computer)
         code = containers.create_chemshell_code(engine)
-        return existed, code.full_label
+        return existed, code.full_label, dq_changed
 
     def _run_install(self) -> None:
         """Run the full detect/build/create sequence (background thread)."""
@@ -156,18 +161,23 @@ class ChemShellContainerSetupWidget(ipw.VBox):
                     return
 
             self._set_status(f"{self._SPINNER} Creating AiiDA code ...", "working")
-            existed, full_label = self._call_on_loop(lambda: self._create_code(engine))
+            existed, full_label, dq_changed = self._call_on_loop(
+                lambda: self._create_code(engine)
+            )
             if existed:
-                self._set_status(
+                message = (
                     f"Code <code>{full_label}</code> already exists and is "
-                    "ready to use.",
-                    "success",
+                    "ready to use."
                 )
             else:
-                self._set_status(
-                    f"Code <code>{full_label}</code> created successfully.",
-                    "success",
+                message = f"Code <code>{full_label}</code> created successfully."
+            if dq_changed:
+                message += (
+                    " Note: enabled <code>use_double_quotes</code> on the "
+                    f"<code>{containers.COMPUTER_LABEL}</code> computer, which is "
+                    "required for containerized codes."
                 )
+            self._set_status(message, "success")
         except Exception as exc:  # noqa: BLE001 - surface any failure in the UI
             self._set_status(f"Unexpected error: {exc}", "error")
         finally:

--- a/src/aiidalab_chemshell/resources.py
+++ b/src/aiidalab_chemshell/resources.py
@@ -1,8 +1,14 @@
 """Defines a resource setup widget based on foundations from aiidalab-widgets-base."""
 
+import asyncio
+import concurrent.futures
+import threading
+
 import aiidalab_widgets_base as awb
 import ipywidgets as ipw
 from traitlets import HasTraits, Unicode, observe
+
+from aiidalab_chemshell import containers
 
 
 class CodeSetupWidget(ipw.VBox, HasTraits):
@@ -42,4 +48,122 @@ class CodeSetupWidget(ipw.VBox, HasTraits):
         self.resource_widget.comp_resources_database.database_source = (
             self._database_source
         )
+        return
+
+
+class ChemShellContainerSetupWidget(VBox):
+    """Widget for one-click install of the ChemShell container and AiiDA code."""
+
+    _SPINNER = "<i class='fa fa-spinner fa-spin fa-fw'></i>"
+
+    def __init__(self, **kwargs):
+        self.install_btn = ipw.Button(
+            description="Install ChemShell Container & Create Code",
+            button_style="success",
+            tooltip="Check Apptainer, build the image and create the AiiDA code",
+            icon="download",
+            layout={"width": "auto"},
+        )
+        self.install_btn.on_click(self._on_install_clicked)
+        self.status = ipw.HTML("")
+
+        children = [
+            self.install_btn,
+            self.status,
+        ]
+        super().__init__(children=children, **kwargs)
+        return
+
+    def _set_status(self, message: str, level: str = "info") -> None:
+        """Update the status area with a colour-coded message."""
+        colours = {
+            "info": "#31708f",
+            "success": "#3c763d",
+            "error": "#a94442",
+            "working": "#8a6d3b",
+        }
+        colour = colours.get(level, colours["info"])
+        self.status.value = f"<p style='color:{colour};'>{message}</p>"
+        return
+
+    def _on_install_clicked(self, _=None) -> None:
+        """Launch the install sequence on a background thread."""
+        self.install_btn.disabled = True
+        # Capture the notebook's event loop so AiiDA ORM work can be marshalled
+        # back onto the main thread (see ``_call_on_loop``).
+        self._loop = asyncio.get_event_loop()
+        thread = threading.Thread(target=self._run_install, daemon=True)
+        thread.start()
+        return
+
+    def _call_on_loop(self, func):
+        """Run ``func`` on the notebook's event loop and return its result.
+
+        AiiDA's storage session is bound to the (main) thread that loaded the
+        profile. ORM operations must therefore run on that thread.
+        """
+        future: concurrent.futures.Future = concurrent.futures.Future()
+
+        def _wrapper():
+            try:
+                future.set_result(func())
+            except Exception as exc:  # noqa: BLE001 - propagated to the worker
+                future.set_exception(exc)
+
+        self._loop.call_soon_threadsafe(_wrapper)
+        return future.result()
+
+    def _create_code(self):
+        """Create/reuse the ChemShell code (must run on the main thread)."""
+        existed = containers.chemshell_code_exists()
+        code = containers.create_chemshell_code()
+        return existed, code.full_label
+
+    def _run_install(self) -> None:
+        """Run the full check/build/create sequence (background thread)."""
+        try:
+            self._set_status(f"{self._SPINNER} Checking Apptainer ...", "working")
+            ok, message = containers.check_apptainer()
+            if not ok:
+                self._set_status(message, "error")
+                return
+
+            if containers.sif_exists():
+                self._set_status(
+                    f"Existing container image found at "
+                    f"<code>{containers.sif_path()}</code>.",
+                    "info",
+                )
+            else:
+                self._set_status(
+                    f"{self._SPINNER} Building container image "
+                    "(this can take several minutes) ...",
+                    "working",
+                )
+                ok, message = containers.build_sif(
+                    on_progress=lambda msg: self._set_status(
+                        f"{self._SPINNER} {msg}", "working"
+                    )
+                )
+                if not ok:
+                    self._set_status(message, "error")
+                    return
+
+            self._set_status(f"{self._SPINNER} Creating AiiDA code ...", "working")
+            existed, full_label = self._call_on_loop(self._create_code)
+            if existed:
+                self._set_status(
+                    f"Code <code>{full_label}</code> already exists and is "
+                    "ready to use.",
+                    "success",
+                )
+            else:
+                self._set_status(
+                    f"Code <code>{full_label}</code> created successfully.",
+                    "success",
+                )
+        except Exception as exc:  # noqa: BLE001 - surface any failure in the UI
+            self._set_status(f"Unexpected error: {exc}", "error")
+        finally:
+            self.install_btn.disabled = False
         return

--- a/src/aiidalab_chemshell/resources.py
+++ b/src/aiidalab_chemshell/resources.py
@@ -51,7 +51,7 @@ class CodeSetupWidget(ipw.VBox, HasTraits):
         return
 
 
-class ChemShellContainerSetupWidget(VBox):
+class ChemShellContainerSetupWidget(ipw.VBox):
     """Widget for one-click install of the ChemShell container and AiiDA code."""
 
     _SPINNER = "<i class='fa fa-spinner fa-spin fa-fw'></i>"

--- a/src/aiidalab_chemshell/resources.py
+++ b/src/aiidalab_chemshell/resources.py
@@ -60,7 +60,9 @@ class ChemShellContainerSetupWidget(ipw.VBox):
         self.install_btn = ipw.Button(
             description="Install ChemShell Container & Create Code",
             button_style="success",
-            tooltip="Check Apptainer, build the image and create the AiiDA code",
+            tooltip=(
+                "Detect Apptainer or Docker, build the image and create the AiiDA code"
+            ),
             icon="download",
             layout={"width": "auto"},
         )
@@ -113,25 +115,28 @@ class ChemShellContainerSetupWidget(ipw.VBox):
         self._loop.call_soon_threadsafe(_wrapper)
         return future.result()
 
-    def _create_code(self):
+    def _create_code(self, engine: str):
         """Create/reuse the ChemShell code (must run on the main thread)."""
         existed = containers.chemshell_code_exists()
-        code = containers.create_chemshell_code()
+        code = containers.create_chemshell_code(engine)
         return existed, code.full_label
 
     def _run_install(self) -> None:
-        """Run the full check/build/create sequence (background thread)."""
+        """Run the full detect/build/create sequence (background thread)."""
         try:
-            self._set_status(f"{self._SPINNER} Checking Apptainer ...", "working")
-            ok, message = containers.check_apptainer()
-            if not ok:
+            self._set_status(
+                f"{self._SPINNER} Checking for a container engine ...", "working"
+            )
+            engine, message = containers.detect_engine()
+            if engine is None:
                 self._set_status(message, "error")
                 return
 
-            if containers.sif_exists():
+            self._set_status(f"Using {engine} ({message}).", "info")
+
+            if containers.image_exists(engine):
                 self._set_status(
-                    f"Existing container image found at "
-                    f"<code>{containers.sif_path()}</code>.",
+                    "Existing container image found; reusing it.",
                     "info",
                 )
             else:
@@ -140,17 +145,18 @@ class ChemShellContainerSetupWidget(ipw.VBox):
                     "(this can take several minutes) ...",
                     "working",
                 )
-                ok, message = containers.build_sif(
+                ok, message = containers.build_image(
+                    engine,
                     on_progress=lambda msg: self._set_status(
                         f"{self._SPINNER} {msg}", "working"
-                    )
+                    ),
                 )
                 if not ok:
                     self._set_status(message, "error")
                     return
 
             self._set_status(f"{self._SPINNER} Creating AiiDA code ...", "working")
-            existed, full_label = self._call_on_loop(self._create_code)
+            existed, full_label = self._call_on_loop(lambda: self._create_code(engine))
             if existed:
                 self._set_status(
                     f"Code <code>{full_label}</code> already exists and is "

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -47,6 +47,99 @@ def test_check_apptainer_broken():
     assert "boom" in message
 
 
+# --- check_docker ---------------------------------------------------------
+
+
+def test_check_docker_available():
+    """Docker present with a reachable daemon reports ok."""
+    with mock.patch.object(
+        containers.subprocess,
+        "run",
+        return_value=_completed(stdout="24.0.7"),
+    ):
+        ok, message = containers.check_docker()
+    assert ok is True
+    assert "24.0.7" in message
+
+
+def test_check_docker_missing():
+    """A missing Docker binary is reported as unavailable."""
+    with mock.patch.object(containers.subprocess, "run", side_effect=FileNotFoundError):
+        ok, message = containers.check_docker()
+    assert ok is False
+    assert "not found" in message.lower()
+
+
+def test_check_docker_daemon_down():
+    """Docker present but the daemon unreachable is reported as an error."""
+    with mock.patch.object(
+        containers.subprocess,
+        "run",
+        return_value=_completed(returncode=1, stderr="Cannot connect to the daemon"),
+    ):
+        ok, message = containers.check_docker()
+    assert ok is False
+    assert "daemon" in message.lower()
+
+
+def test_check_docker_uses_server_version_command():
+    """The availability check queries the Docker server version."""
+    with mock.patch.object(
+        containers.subprocess, "run", return_value=_completed(stdout="v")
+    ) as run:
+        containers.check_docker()
+    args = run.call_args.args[0]
+    assert args[:2] == ["docker", "version"]
+    assert "{{.Server.Version}}" in args
+    assert run.call_args.kwargs.get("check") is False
+
+
+# --- detect_engine --------------------------------------------------------
+
+
+def test_detect_engine_prefers_apptainer():
+    """Apptainer is chosen when available, without checking Docker."""
+    with (
+        mock.patch.object(
+            containers, "check_apptainer", return_value=(True, "apptainer 1.3.0")
+        ),
+        mock.patch.object(containers, "check_docker") as check_docker,
+    ):
+        engine, message = containers.detect_engine()
+    assert engine == containers.APPTAINER
+    assert "1.3.0" in message
+    check_docker.assert_not_called()
+
+
+def test_detect_engine_falls_back_to_docker():
+    """Docker is chosen when Apptainer is unavailable."""
+    with (
+        mock.patch.object(
+            containers, "check_apptainer", return_value=(False, "no apptainer")
+        ),
+        mock.patch.object(containers, "check_docker", return_value=(True, "24.0.7")),
+    ):
+        engine, message = containers.detect_engine()
+    assert engine == containers.DOCKER
+    assert "24.0.7" in message
+
+
+def test_detect_engine_none_available():
+    """When neither engine is present, None is returned with both reasons."""
+    with (
+        mock.patch.object(
+            containers, "check_apptainer", return_value=(False, "no apptainer")
+        ),
+        mock.patch.object(
+            containers, "check_docker", return_value=(False, "no docker")
+        ),
+    ):
+        engine, message = containers.detect_engine()
+    assert engine is None
+    assert "no apptainer" in message
+    assert "no docker" in message
+
+
 # --- build_sif ------------------------------------------------------------
 
 
@@ -81,6 +174,93 @@ def test_build_sif_failure(tmp_path):
         ok, message = containers.build_sif()
     assert ok is False
     assert "registry unreachable" in message
+
+
+# --- docker image helpers -------------------------------------------------
+
+
+def test_docker_image_exists_true():
+    """A zero return code from ``docker image inspect`` means present."""
+    with mock.patch.object(
+        containers.subprocess, "run", return_value=_completed()
+    ) as run:
+        assert containers.docker_image_exists() is True
+    args = run.call_args.args[0]
+    assert args[:3] == ["docker", "image", "inspect"]
+    assert args[-1] == containers.DOCKER_IMAGE
+
+
+def test_docker_image_exists_false_when_absent():
+    """A non-zero return code means the image is not present."""
+    with mock.patch.object(
+        containers.subprocess, "run", return_value=_completed(returncode=1)
+    ):
+        assert containers.docker_image_exists() is False
+
+
+def test_docker_image_exists_false_when_missing_binary():
+    """A missing Docker binary reports the image as absent."""
+    with mock.patch.object(containers.subprocess, "run", side_effect=FileNotFoundError):
+        assert containers.docker_image_exists() is False
+
+
+def test_pull_docker_image_success():
+    """A successful pull returns ok and reports progress."""
+    progress = []
+    with mock.patch.object(
+        containers.subprocess, "run", return_value=_completed()
+    ) as run:
+        ok, message = containers.pull_docker_image(on_progress=progress.append)
+    assert ok is True
+    assert progress
+    args = run.call_args.args[0]
+    assert args[:2] == ["docker", "pull"]
+    assert args[-1] == containers.DOCKER_IMAGE
+
+
+def test_pull_docker_image_failure():
+    """A failing pull surfaces the captured error output."""
+    with mock.patch.object(
+        containers.subprocess,
+        "run",
+        return_value=_completed(returncode=1, stderr="manifest unknown"),
+    ):
+        ok, message = containers.pull_docker_image()
+    assert ok is False
+    assert "manifest unknown" in message
+
+
+# --- engine-agnostic routers ----------------------------------------------
+
+
+def test_image_exists_routes_by_engine():
+    """image_exists dispatches to the sif / docker checks per engine."""
+    with (
+        mock.patch.object(containers, "sif_exists", return_value=True) as sif,
+        mock.patch.object(
+            containers, "docker_image_exists", return_value=False
+        ) as docker,
+    ):
+        assert containers.image_exists(containers.APPTAINER) is True
+        assert containers.image_exists(containers.DOCKER) is False
+    sif.assert_called_once()
+    docker.assert_called_once()
+
+
+def test_build_image_routes_by_engine():
+    """build_image dispatches to build_sif / pull_docker_image per engine."""
+    with (
+        mock.patch.object(
+            containers, "build_sif", return_value=(True, "sif")
+        ) as build_sif,
+        mock.patch.object(
+            containers, "pull_docker_image", return_value=(True, "docker")
+        ) as pull,
+    ):
+        assert containers.build_image(containers.APPTAINER) == (True, "sif")
+        assert containers.build_image(containers.DOCKER) == (True, "docker")
+    build_sif.assert_called_once()
+    pull.assert_called_once()
 
 
 # --- create_chemshell_code ------------------------------------------------
@@ -119,12 +299,31 @@ def test_create_chemshell_code_creates_new():
 
     kwargs = containerized.call_args.kwargs
     assert kwargs["computer"] is computer
-    assert kwargs["engine_command"] == containers.ENGINE_COMMAND
+    assert kwargs["engine_command"] == containers.APPTAINER_ENGINE_COMMAND
     assert "{image_name}" in kwargs["engine_command"]
     assert kwargs["image_name"] == str(containers.sif_path())
     assert kwargs["filepath_executable"] == containers.FILEPATH_EXECUTABLE
     assert kwargs["label"] == containers.CODE_LABEL
     assert kwargs["default_calc_job_plugin"] == containers.DEFAULT_CALC_JOB_PLUGIN
+
+
+def test_create_chemshell_code_docker_engine():
+    """Requesting the Docker engine builds a code with the docker settings."""
+    computer = mock.Mock()
+    code = mock.Mock()
+    with (
+        mock.patch.object(containers, "chemshell_code_exists", return_value=False),
+        mock.patch.object(containers, "get_localhost_computer", return_value=computer),
+        mock.patch("aiida.orm.ContainerizedCode", return_value=code) as containerized,
+    ):
+        result = containers.create_chemshell_code(engine=containers.DOCKER)
+
+    assert result is code
+    kwargs = containerized.call_args.kwargs
+    assert kwargs["engine_command"] == containers.DOCKER_ENGINE_COMMAND
+    assert "{image_name}" in kwargs["engine_command"]
+    assert kwargs["image_name"] == containers.DOCKER_IMAGE
+    assert "Docker" in kwargs["description"]
 
 
 # --- chemshell_code_exists ------------------------------------------------

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -326,6 +326,41 @@ def test_create_chemshell_code_docker_engine():
     assert "Docker" in kwargs["description"]
 
 
+def test_create_chemshell_code_enforces_double_quotes():
+    """Creating a code enables double-quote escaping on the computer."""
+    computer = mock.Mock()
+    computer.get_use_double_quotes.return_value = False
+    code = mock.Mock()
+    with (
+        mock.patch.object(containers, "chemshell_code_exists", return_value=False),
+        mock.patch.object(containers, "get_localhost_computer", return_value=computer),
+        mock.patch("aiida.orm.ContainerizedCode", return_value=code),
+    ):
+        containers.create_chemshell_code()
+    computer.set_use_double_quotes.assert_called_once_with(True)
+
+
+# --- ensure_use_double_quotes ---------------------------------------------
+
+
+def test_ensure_use_double_quotes_sets_when_disabled():
+    """A computer with double quotes disabled is updated and reports a change."""
+    computer = mock.Mock()
+    computer.get_use_double_quotes.return_value = False
+    changed = containers.ensure_use_double_quotes(computer)
+    assert changed is True
+    computer.set_use_double_quotes.assert_called_once_with(True)
+
+
+def test_ensure_use_double_quotes_noop_when_enabled():
+    """A computer that already uses double quotes is left untouched."""
+    computer = mock.Mock()
+    computer.get_use_double_quotes.return_value = True
+    changed = containers.ensure_use_double_quotes(computer)
+    assert changed is False
+    computer.set_use_double_quotes.assert_not_called()
+
+
 # --- chemshell_code_exists ------------------------------------------------
 
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,173 @@
+"""Tests for the ChemShell container install / code creation logic."""
+
+import subprocess
+from types import SimpleNamespace
+from unittest import mock
+
+from aiidalab_chemshell import containers
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    """Build a fake ``subprocess.CompletedProcess``-like object."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# --- check_apptainer ------------------------------------------------------
+
+
+def test_check_apptainer_available():
+    """Apptainer present and returning successfully reports ok."""
+    with mock.patch.object(
+        containers.subprocess,
+        "run",
+        return_value=_completed(stdout="apptainer version 1.3.0"),
+    ):
+        ok, message = containers.check_apptainer()
+    assert ok is True
+    assert "1.3.0" in message
+
+
+def test_check_apptainer_missing():
+    """A missing Apptainer binary is reported as unavailable."""
+    with mock.patch.object(containers.subprocess, "run", side_effect=FileNotFoundError):
+        ok, message = containers.check_apptainer()
+    assert ok is False
+    assert "not found" in message.lower()
+
+
+def test_check_apptainer_broken():
+    """Apptainer present but exiting non-zero is reported as an error."""
+    with mock.patch.object(
+        containers.subprocess,
+        "run",
+        return_value=_completed(returncode=1, stderr="boom"),
+    ):
+        ok, message = containers.check_apptainer()
+    assert ok is False
+    assert "boom" in message
+
+
+# --- build_sif ------------------------------------------------------------
+
+
+def test_build_sif_success(tmp_path):
+    """A successful pull returns ok and reports progress."""
+    progress = []
+    with (
+        mock.patch.object(containers, "CONTAINER_DIR", tmp_path),
+        mock.patch.object(
+            containers.subprocess, "run", return_value=_completed()
+        ) as run,
+    ):
+        ok, message = containers.build_sif(on_progress=progress.append)
+    assert ok is True
+    assert progress  # at least one progress message emitted
+    # The pull command targets the expected sif path and image uri.
+    args = run.call_args.args[0]
+    assert args[:2] == ["apptainer", "pull"]
+    assert args[-1] == containers.CONTAINER_IMAGE_URI
+
+
+def test_build_sif_failure(tmp_path):
+    """A failing pull surfaces the captured error output."""
+    with (
+        mock.patch.object(containers, "CONTAINER_DIR", tmp_path),
+        mock.patch.object(
+            containers.subprocess,
+            "run",
+            return_value=_completed(returncode=255, stderr="registry unreachable"),
+        ),
+    ):
+        ok, message = containers.build_sif()
+    assert ok is False
+    assert "registry unreachable" in message
+
+
+# --- create_chemshell_code ------------------------------------------------
+
+
+def test_create_chemshell_code_reuses_existing():
+    """An existing code is loaded and returned without creating a new one."""
+    existing = mock.Mock()
+    with (
+        mock.patch.object(containers, "chemshell_code_exists", return_value=True),
+        mock.patch("aiida.orm.load_code", return_value=existing) as load_code,
+        mock.patch("aiida.orm.ContainerizedCode") as containerized,
+    ):
+        result = containers.create_chemshell_code()
+    assert result is existing
+    load_code.assert_called_once_with(
+        f"{containers.CODE_LABEL}@{containers.COMPUTER_LABEL}"
+    )
+    containerized.assert_not_called()
+
+
+def test_create_chemshell_code_creates_new():
+    """When no code exists a ContainerizedCode is built, stored and unhidden."""
+    computer = mock.Mock()
+    code = mock.Mock()
+    with (
+        mock.patch.object(containers, "chemshell_code_exists", return_value=False),
+        mock.patch.object(containers, "get_localhost_computer", return_value=computer),
+        mock.patch("aiida.orm.ContainerizedCode", return_value=code) as containerized,
+    ):
+        result = containers.create_chemshell_code()
+
+    assert result is code
+    code.store.assert_called_once()
+    assert code.is_hidden is False
+
+    kwargs = containerized.call_args.kwargs
+    assert kwargs["computer"] is computer
+    assert kwargs["engine_command"] == containers.ENGINE_COMMAND
+    assert "{image_name}" in kwargs["engine_command"]
+    assert kwargs["image_name"] == str(containers.sif_path())
+    assert kwargs["filepath_executable"] == containers.FILEPATH_EXECUTABLE
+    assert kwargs["label"] == containers.CODE_LABEL
+    assert kwargs["default_calc_job_plugin"] == containers.DEFAULT_CALC_JOB_PLUGIN
+
+
+# --- chemshell_code_exists ------------------------------------------------
+
+
+def test_chemshell_code_exists_false_when_not_found():
+    """A missing code is reported via the NotExistent exception path."""
+    from aiida.common.exceptions import NotExistent
+
+    with mock.patch("aiida.orm.load_code", side_effect=NotExistent):
+        assert containers.chemshell_code_exists() is False
+
+
+def test_chemshell_code_exists_true_when_found():
+    """An existing code is reported as present."""
+    with mock.patch("aiida.orm.load_code", return_value=mock.Mock()):
+        assert containers.chemshell_code_exists() is True
+
+
+# --- sif helpers ----------------------------------------------------------
+
+
+def test_sif_path_and_exists(tmp_path):
+    """sif_path/sif_exists reflect the configured container directory."""
+    with mock.patch.object(containers, "CONTAINER_DIR", tmp_path):
+        path = containers.sif_path()
+        assert path == tmp_path / containers.SIF_FILENAME
+        assert containers.sif_exists() is False
+        path.write_text("")
+        assert containers.sif_exists() is True
+
+
+def test_check_apptainer_uses_expected_command():
+    """The availability check invokes ``apptainer --version``."""
+    with mock.patch.object(
+        containers.subprocess, "run", return_value=_completed(stdout="v")
+    ) as run:
+        containers.check_apptainer()
+    assert run.call_args.args[0] == ["apptainer", "--version"]
+    # Guard against subprocess raising on non-zero exit.
+    assert run.call_args.kwargs.get("check") is False
+
+
+# Ensure the module exposes subprocess for patching stability.
+assert hasattr(containers, "subprocess")
+assert issubclass(subprocess.SubprocessError, Exception)


### PR DESCRIPTION
Adds a "Quick Install" section on the resource management page which specifically refers to setting up a local ChemShell code instance. This relies on a containerised version of ChemShell (currently v25) and so the code first checks for an available container engine, currently supporting Apptainer (preferred) and docker. Once this has been identified it will then download the ChemShell container and configure the local code instance for use within AiiDA/AiiDAlab. 

Note: This will not work if running AiiDAlab through the provided docker containers, without additional modification of the containers. 